### PR TITLE
Update for accent 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.6.0
+FROM elixir:1.8
 MAINTAINER Sven Gehring <sgehring@kochag.ch>
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: "3.2"
 
 services: 
   accent:
-    build: ./accent
+    build: .
     links:
       - postgres
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.2"
+
+services: 
+  accent:
+    build: .
+    links:
+      - postgres
+    ports:
+      - 4000:4000
+      - 4200:4200
+    environment:
+      MIX_ENV: dev
+      PORT: 4000
+      WEBAPP_PORT: 4200
+      DATABASE_URL: postgres://postgres:password@postgres/accent_development
+
+  postgres:
+    image: postgres:10.4
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    volumes:
+      - postgresdata:/var/lib/postgresql/data
+
+volumes:
+  postgresdata:
+    driver: local


### PR DESCRIPTION
Fixing nested accent folder for build:
`build: ./accent` -> `build: .`

Also updated elixir version in dockerfile to support 1.0.0